### PR TITLE
Upgrading to include OAC configurations. Also, fixing issue where targeted applies were necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 .DS_Store
 target
 CHANGELOG.md
-*.tfstate
-*.tfstate.backup
+*.tfstate*

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,22 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.27.0"
+  version     = "4.36.1"
   constraints = ">= 4.5.0, >= 4.27.0"
   hashes = [
-    "h1:JjDRnFkYnMTgW1OJclVkE7ucHPFXwhNzrdexhtj97Lo=",
-    "h1:w3j7YomUQ9IfRp3MUuY0+hFX1T1cawZoj0Xsc1a46bU=",
-    "zh:0f5ade3801fec487641e4f7d81e28075b716c787772f9709cc2378d20f325791",
-    "zh:19ffa83be6b6765a4f821a17b8d260dd0f192a6c40765fa53ac65fd042cb1f65",
-    "zh:3ac89d33ff8ca75bdc42f31c63ce0018ffc66aa69917c18713e824e381950e4e",
-    "zh:81a199724e74992c8a029a968d211cb45277d95a2e88d0f07ec85127b6c6849b",
+    "h1:bVdhic55ukDoSukFwOOqX2q/gZ5efe4aBTMGivEuY4o=",
+    "zh:19b16047b4f15e9b8538a2b925f1e860463984eed7d9bd78e870f3e884e827a7",
+    "zh:3c0db06a9a14b05a77f3fe1fc029a5fb153f4966964790ca8e71ecc3427d83f5",
+    "zh:3c7407a8229005e07bc274cbae6e3a464c441a88810bfc6eceb2414678fd08ae",
+    "zh:3d96fa82c037fafbd3e7f4edc1de32afb029416650f6e392c39182fc74a9e03a",
+    "zh:8f4f540c5f63d847c4b802ca84d148bb6275a3b0723deb09bf933a4800bc7209",
+    "zh:9802cb77472d6bcf24c196ce2ca6d02fac9db91558536325fec85f955b71a8a4",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2e2c851a37ef97bbccccd2e686b4d016abe207a7f56bff70b10bfdf8ed1cbfd",
-    "zh:baf844def338d77f8a3106b1411a1fe22e93a82e3dc51e5d33b766f741c4a6a3",
-    "zh:bc33137fae808f91da0a9de7031cbea77d0ee4eefb4d2ad6ab7f58cc2111a7ff",
-    "zh:c960ae2b33c8d3327f67a3db5ce1952315146d69dfc3f1b0922242e2b218eec8",
-    "zh:f3ea1a25797c79c035463a1188a6a42e131f391f3cb714975ce49ccd301cda07",
-    "zh:f7e77c871d38236e5fedee0086ff77ff396e88964348c794cf38e578fcc00293",
-    "zh:fb338d5dfafab907b8608bd66cad8ca9ae4679f8c62c2435c2056a38b719baa2",
+    "zh:a263352433878c89832c2e38f4fd56cf96ae9969c13b5c710d5ba043cbd95743",
+    "zh:aca7954a5f458ceb14bf0c04c961c4e1e9706bf3b854a1e90a97d0b20f0fe6d3",
+    "zh:d78f400332e87a97cce2e080db9d01beb01f38f5402514a6705d6b8167e7730d",
+    "zh:e14bdc49be1d8b7d2543d5c58078c84b76051085e8e6715a895dcfe6034b6098",
+    "zh:f2e400b88c8de170bb5027922226da1e9a6614c03f2a6756c15c3b930c2f460c",
   ]
 }

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-terraform 1.2.4
+terraform 1.3.3
 golang 1.18.1
 ripgrep 13.0.0
 tflint 0.34.1

--- a/README-HEADER.md
+++ b/README-HEADER.md
@@ -34,18 +34,6 @@ module "static-website" {
 }
 ```
 
-### :warning: Warning
-
-This module requires a targeted apply to start using it.
-
-The following command will apply the resources that need to be created in order to finish applying (assuming you name the module `static_website`):
-
-```bash
-terraform apply \
--target='module.static_website.module.s3.aws_s3_bucket.bucket' \
--target='module.static_website.data.aws_iam_policy_document.policy_doc'
-```
-
 ## Adding This Version of the Module
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-static-website-module?ref=1.1.0
+github.com/pbs/terraform-aws-static-website-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -22,7 +22,7 @@ Integrate this module like so:
 
 ```hcl
 module "static-website" {
-  source = "github.com/pbs/terraform-aws-static-website-module?ref=1.1.0"
+  source = "github.com/pbs/terraform-aws-static-website-module?ref=x.y.z"
 
   # Tagging Parameters
   organization = var.organization
@@ -34,23 +34,11 @@ module "static-website" {
 }
 ```
 
-### :warning: Warning
-
-This module requires a targeted apply to start using it.
-
-The following command will apply the resources that need to be created in order to finish applying (assuming you name the module `static_website`):
-
-```bash
-terraform apply \
--target='module.static_website.module.s3.aws_s3_bucket.bucket' \
--target='module.static_website.data.aws_iam_policy_document.policy_doc'
-```
-
 ## Adding This Version of the Module
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`1.1.0`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -66,27 +54,24 @@ Below is automatically generated documentation on this Terraform module using [t
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.27.0 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.27.0 |
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloudfront"></a> [cloudfront](#module\_cloudfront) | github.com/pbs/terraform-aws-cloudfront-module | 1.0.0 |
-| <a name="module_s3"></a> [s3](#module\_s3) | github.com/pbs/terraform-aws-s3-module | 0.1.0 |
+| <a name="module_cloudfront"></a> [cloudfront](#module\_cloudfront) | github.com/pbs/terraform-aws-cloudfront-module | 2.0.0 |
+| <a name="module_s3"></a> [s3](#module\_s3) | github.com/pbs/terraform-aws-s3-module | 0.2.0 |
+| <a name="module_s3_policy"></a> [s3\_policy](#module\_s3\_policy) | github.com/pbs/terraform-aws-s3-bucket-policy-module | 1.0.0 |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_iam_policy_document.policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+No resources.
 
 ## Inputs
 
@@ -167,4 +152,4 @@ Below is automatically generated documentation on this Terraform module using [t
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Bucket backing this CDN. |
 | <a name="output_domain_name"></a> [domain\_name](#output\_domain\_name) | One domain name that will resolve to this cdn. Might not be a valid alias. |
 | <a name="output_id"></a> [id](#output\_id) | ID of the CloudFront distribution |
-| <a name="output_oia_arns"></a> [oia\_arns](#output\_oia\_arns) | Origin Access Identity ARNs |
+| <a name="output_oac_id"></a> [oac\_id](#output\_oac\_id) | ID of the origin access identity |

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ No resources.
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `true` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `true` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name to use for the bucket. If null, will default to product. | `string` | `null` | no |
-| <a name="input_bucket_policy"></a> [bucket\_policy](#input\_bucket\_policy) | Policy to apply to the bucket. If null, one will be guessed based on surrounding functionality | `string` | `null` | no |
 | <a name="input_cloudfront_default_certificate"></a> [cloudfront\_default\_certificate](#input\_cloudfront\_default\_certificate) | (optional) use cloudfront default ssl certificate | `bool` | `false` | no |
 | <a name="input_cnames"></a> [cnames](#input\_cnames) | (optional) CNAME(s) that are going to be created for this cdn in the primary\_hosted\_zone. This can be set to [] to avoid creating a CNAME for the app. This can be useful for CDNs. Default is `product`. e.g. [service] --> [example.example.com] | `list(string)` | `null` | no |
 | <a name="input_comment"></a> [comment](#input\_comment) | (optional) comment for the CDN | `string` | `null` | no |

--- a/examples/basic/.terraform.lock.hcl
+++ b/examples/basic/.terraform.lock.hcl
@@ -2,9 +2,22 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.27.0"
+  version     = "4.36.1"
   constraints = ">= 4.5.0, >= 4.27.0"
   hashes = [
-    "h1:JjDRnFkYnMTgW1OJclVkE7ucHPFXwhNzrdexhtj97Lo=",
+    "h1:04NI9x34nwhgghwevSGdsjssqy5zzvMsQg2Qjpmx/n0=",
+    "h1:bVdhic55ukDoSukFwOOqX2q/gZ5efe4aBTMGivEuY4o=",
+    "zh:19b16047b4f15e9b8538a2b925f1e860463984eed7d9bd78e870f3e884e827a7",
+    "zh:3c0db06a9a14b05a77f3fe1fc029a5fb153f4966964790ca8e71ecc3427d83f5",
+    "zh:3c7407a8229005e07bc274cbae6e3a464c441a88810bfc6eceb2414678fd08ae",
+    "zh:3d96fa82c037fafbd3e7f4edc1de32afb029416650f6e392c39182fc74a9e03a",
+    "zh:8f4f540c5f63d847c4b802ca84d148bb6275a3b0723deb09bf933a4800bc7209",
+    "zh:9802cb77472d6bcf24c196ce2ca6d02fac9db91558536325fec85f955b71a8a4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a263352433878c89832c2e38f4fd56cf96ae9969c13b5c710d5ba043cbd95743",
+    "zh:aca7954a5f458ceb14bf0c04c961c4e1e9706bf3b854a1e90a97d0b20f0fe6d3",
+    "zh:d78f400332e87a97cce2e080db9d01beb01f38f5402514a6705d6b8167e7730d",
+    "zh:e14bdc49be1d8b7d2543d5c58078c84b76051085e8e6715a895dcfe6034b6098",
+    "zh:f2e400b88c8de170bb5027922226da1e9a6614c03f2a6756c15c3b930c2f460c",
   ]
 }

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -8,7 +8,7 @@ output "domain_name" {
   value       = module.static_website.domain_name
 }
 
-output "oia_arns" {
-  description = "Origin Access Identity ARNs"
-  value       = module.static_website.oia_arns
+output "oac_id" {
+  description = "ID of the origin access identity"
+  value       = module.static_website.oac_id
 }

--- a/examples/cors/.terraform.lock.hcl
+++ b/examples/cors/.terraform.lock.hcl
@@ -2,9 +2,22 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.27.0"
+  version     = "4.36.1"
   constraints = ">= 4.5.0, >= 4.27.0"
   hashes = [
-    "h1:JjDRnFkYnMTgW1OJclVkE7ucHPFXwhNzrdexhtj97Lo=",
+    "h1:04NI9x34nwhgghwevSGdsjssqy5zzvMsQg2Qjpmx/n0=",
+    "h1:bVdhic55ukDoSukFwOOqX2q/gZ5efe4aBTMGivEuY4o=",
+    "zh:19b16047b4f15e9b8538a2b925f1e860463984eed7d9bd78e870f3e884e827a7",
+    "zh:3c0db06a9a14b05a77f3fe1fc029a5fb153f4966964790ca8e71ecc3427d83f5",
+    "zh:3c7407a8229005e07bc274cbae6e3a464c441a88810bfc6eceb2414678fd08ae",
+    "zh:3d96fa82c037fafbd3e7f4edc1de32afb029416650f6e392c39182fc74a9e03a",
+    "zh:8f4f540c5f63d847c4b802ca84d148bb6275a3b0723deb09bf933a4800bc7209",
+    "zh:9802cb77472d6bcf24c196ce2ca6d02fac9db91558536325fec85f955b71a8a4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a263352433878c89832c2e38f4fd56cf96ae9969c13b5c710d5ba043cbd95743",
+    "zh:aca7954a5f458ceb14bf0c04c961c4e1e9706bf3b854a1e90a97d0b20f0fe6d3",
+    "zh:d78f400332e87a97cce2e080db9d01beb01f38f5402514a6705d6b8167e7730d",
+    "zh:e14bdc49be1d8b7d2543d5c58078c84b76051085e8e6715a895dcfe6034b6098",
+    "zh:f2e400b88c8de170bb5027922226da1e9a6614c03f2a6756c15c3b930c2f460c",
   ]
 }

--- a/examples/cors/outputs.tf
+++ b/examples/cors/outputs.tf
@@ -8,7 +8,7 @@ output "domain_name" {
   value       = module.static_website.domain_name
 }
 
-output "oia_arns" {
-  description = "Origin Access Identity ARNs"
-  value       = module.static_website.oia_arns
+output "oac_id" {
+  description = "ID of the origin access identity"
+  value       = module.static_website.oac_id
 }

--- a/examples/policies/.terraform.lock.hcl
+++ b/examples/policies/.terraform.lock.hcl
@@ -2,9 +2,22 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.27.0"
+  version     = "4.36.1"
   constraints = ">= 4.5.0, >= 4.27.0"
   hashes = [
-    "h1:JjDRnFkYnMTgW1OJclVkE7ucHPFXwhNzrdexhtj97Lo=",
+    "h1:04NI9x34nwhgghwevSGdsjssqy5zzvMsQg2Qjpmx/n0=",
+    "h1:bVdhic55ukDoSukFwOOqX2q/gZ5efe4aBTMGivEuY4o=",
+    "zh:19b16047b4f15e9b8538a2b925f1e860463984eed7d9bd78e870f3e884e827a7",
+    "zh:3c0db06a9a14b05a77f3fe1fc029a5fb153f4966964790ca8e71ecc3427d83f5",
+    "zh:3c7407a8229005e07bc274cbae6e3a464c441a88810bfc6eceb2414678fd08ae",
+    "zh:3d96fa82c037fafbd3e7f4edc1de32afb029416650f6e392c39182fc74a9e03a",
+    "zh:8f4f540c5f63d847c4b802ca84d148bb6275a3b0723deb09bf933a4800bc7209",
+    "zh:9802cb77472d6bcf24c196ce2ca6d02fac9db91558536325fec85f955b71a8a4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a263352433878c89832c2e38f4fd56cf96ae9969c13b5c710d5ba043cbd95743",
+    "zh:aca7954a5f458ceb14bf0c04c961c4e1e9706bf3b854a1e90a97d0b20f0fe6d3",
+    "zh:d78f400332e87a97cce2e080db9d01beb01f38f5402514a6705d6b8167e7730d",
+    "zh:e14bdc49be1d8b7d2543d5c58078c84b76051085e8e6715a895dcfe6034b6098",
+    "zh:f2e400b88c8de170bb5027922226da1e9a6614c03f2a6756c15c3b930c2f460c",
   ]
 }

--- a/examples/policies/outputs.tf
+++ b/examples/policies/outputs.tf
@@ -8,7 +8,7 @@ output "domain_name" {
   value       = module.static_website.domain_name
 }
 
-output "oia_arns" {
-  description = "Origin Access Identity ARNs"
-  value       = module.static_website.oia_arns
+output "oac_id" {
+  description = "ID of the origin access identity"
+  value       = module.static_website.oac_id
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,5 @@
 locals {
-  name                             = var.name != null ? var.name : var.product
-  s3_origin_config                 = module.s3.name
-  s3_regional_domain_name          = var.s3_regional_domain_name != null ? var.s3_regional_domain_name : module.s3.regional_domain_name
-  create_replication_target_policy = var.replication_source != null
+  name                    = var.name != null ? var.name : var.product
+  s3_origin_config        = module.s3.name
+  s3_regional_domain_name = var.s3_regional_domain_name != null ? var.s3_regional_domain_name : module.s3.regional_domain_name
 }

--- a/locals.tf
+++ b/locals.tf
@@ -3,5 +3,4 @@ locals {
   s3_origin_config                 = module.s3.name
   s3_regional_domain_name          = var.s3_regional_domain_name != null ? var.s3_regional_domain_name : module.s3.regional_domain_name
   create_replication_target_policy = var.replication_source != null
-  bucket_policy                    = var.bucket_policy != null ? var.bucket_policy : data.aws_iam_policy_document.policy_doc.json
 }

--- a/main.tf
+++ b/main.tf
@@ -119,5 +119,10 @@ module "s3_policy" {
     path           = "*"
   }]
 
+  replication_source = var.replication_source
+
+  source_policy_documents   = var.source_policy_documents
+  override_policy_documents = var.override_policy_documents
+
   product = var.product
 }

--- a/optional-s3.tf
+++ b/optional-s3.tf
@@ -129,12 +129,6 @@ variable "replication_source" {
   })
 }
 
-variable "bucket_policy" {
-  description = "Policy to apply to the bucket. If null, one will be guessed based on surrounding functionality"
-  default     = null
-  type        = string
-}
-
 variable "allow_anonymous_vpce_access" {
   description = "Create bucket policy that allows anonymous VPCE access. If bucket_policy is defined, this will be ignored."
   default     = false

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ output "bucket_arn" {
   value       = module.s3.arn
 }
 
-output "oia_arns" {
-  description = "Origin Access Identity ARNs"
-  value       = module.cloudfront.oia_arns
+output "oac_id" {
+  description = "ID of the origin access identity"
+  value       = module.cloudfront.oac_id
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2.4"
+  required_version = ">= 1.3.2"
   required_providers {
     # tflint-ignore: terraform_unused_required_providers
     aws = {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func TestBasicExample(t *testing.T) {
-	testTemplate(t, "basic")
+	testStaticSite(t, "basic")
 }

--- a/tests/cors_test.go
+++ b/tests/cors_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func TestCorsExample(t *testing.T) {
-	testTemplate(t, "cors")
+	testStaticSite(t, "cors")
 }

--- a/tests/policies_test.go
+++ b/tests/policies_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func TestPoliciesExample(t *testing.T) {
-	testTemplate(t, "policies")
+	testStaticSite(t, "policies")
 }

--- a/tests/utilities_static_site.go
+++ b/tests/utilities_static_site.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testTemplate(t *testing.T, variant string) {
+func testStaticSite(t *testing.T, variant string) {
 	t.Parallel()
 
 	expectedName := fmt.Sprintf("example-tf-static-website-%s", variant)
@@ -32,27 +32,6 @@ func testTemplate(t *testing.T, variant string) {
 	defer terraform.Destroy(t, terraformOptions)
 
 	terraform.Init(t, terraformOptions)
-
-	// This is required because Terraform doesn't like
-	// it that it can't know if the data source below is necessary before
-	// running the plan.
-	terraformBucketTargetOptions := &terraform.Options{
-		TerraformDir: terraformDir,
-		LockTimeout:  "5m",
-		Targets: []string{
-			"module.static_website.module.s3.aws_s3_bucket.bucket",
-		},
-	}
-	terraform.Apply(t, terraformBucketTargetOptions)
-
-	terraformPolicyTargetOptions := &terraform.Options{
-		TerraformDir: terraformDir,
-		LockTimeout:  "5m",
-		Targets: []string{
-			"module.static_website.data.aws_iam_policy_document.policy_doc",
-		},
-	}
-	terraform.Apply(t, terraformPolicyTargetOptions)
 
 	terraform.Apply(t, terraformOptions)
 


### PR DESCRIPTION
By using a separate bucket policy module instead of allowing the S3 module to handle the bucket policy, Terraform is able to order applies in such a way that a targeted apply isn't necessary.